### PR TITLE
#1: Implement Player Movement

### DIFF
--- a/Assets/PreFabs/Player.prefab
+++ b/Assets/PreFabs/Player.prefab
@@ -12,6 +12,8 @@ GameObject:
   - component: {fileID: 3573962375269583936}
   - component: {fileID: 9003082116989057359}
   - component: {fileID: 3494065360675836337}
+  - component: {fileID: 3328828937920806660}
+  - component: {fileID: 6283407140860273542}
   m_Layer: 3
   m_Name: Player
   m_TagString: Untagged
@@ -186,6 +188,50 @@ PolygonCollider2D:
       - {x: 0.4160782, y: -1.5849714}
       - {x: 0.6295974, y: -1.2031605}
       - {x: 1.4882385, y: -1.1545669}
+--- !u!114 &3328828937920806660
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7168460345335854446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf33d98e79d217e41b19cee56586bb77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _boundaryCamera: {fileID: 0}
+  _movementSpeed: 8
+--- !u!114 &6283407140860273542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7168460345335854446}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 78038157bc80e3f488239371a8ab230c, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Arena
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
 --- !u!1 &7898890131661909194
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LevelOne.unity
+++ b/Assets/Scenes/LevelOne.unity
@@ -139,12 +139,24 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.0823798
+      value: 7.62
       objectReference: {fileID: 0}
     - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -2.0366132
+      value: -1.04
       objectReference: {fileID: 0}
     - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
       propertyPath: m_LocalPosition.z
@@ -176,6 +188,22 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1491892379338359423, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9117508542863039788, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 6200000, guid: 1021db9ccb5cff1458f2a737858f6d9b, type: 2}
+    - target: {fileID: 9117508542863039788, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_Constraints
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 9117508542863039788, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_Interpolate
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9117508542863039788, guid: 307ec9f9bc8ebf6439587e084ccf5c54, type: 3}
+      propertyPath: m_CollisionDetection
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -233,7 +261,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 5.01
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -281,11 +309,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7601065754338721927, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 1.9817768
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7601065754338721927, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -3.667426
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7601065754338721927, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
       propertyPath: m_LocalPosition.z
@@ -319,8 +347,73 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
       objectReference: {fileID: 0}
+    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+      propertyPath: m_Material
+      value: 
+      objectReference: {fileID: 6200000, guid: 1021db9ccb5cff1458f2a737858f6d9b, type: 2}
+    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+      propertyPath: m_Interpolate
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+      propertyPath: m_GravityScale
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+      propertyPath: m_CollisionDetection
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+--- !u!1 &577435248 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7168460345335854446, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+  m_PrefabInstance: {fileID: 577435247}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &577435255
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577435248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cf33d98e79d217e41b19cee56586bb77, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _boundaryCamera: {fileID: 487259603}
+  _movementSpeed: 8
+--- !u!114 &577435256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577435248}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: 78038157bc80e3f488239371a8ab230c, type: 3}
+  m_NotificationBehavior: 0
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents: []
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: 
+  m_DefaultActionMap: Arena
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}
 --- !u!1 &1269678582
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/LevelOne.unity
+++ b/Assets/Scenes/LevelOne.unity
@@ -299,6 +299,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3328828937920806660, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
+      propertyPath: _boundaryCamera
+      value: 
+      objectReference: {fileID: 487259603}
     - target: {fileID: 7168460345335854446, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
       propertyPath: m_Name
       value: Player
@@ -347,73 +351,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 90
       objectReference: {fileID: 0}
-    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
-      propertyPath: m_Material
-      value: 
-      objectReference: {fileID: 6200000, guid: 1021db9ccb5cff1458f2a737858f6d9b, type: 2}
-    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
-      propertyPath: m_Interpolate
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
-      propertyPath: m_GravityScale
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 9003082116989057359, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
-      propertyPath: m_CollisionDetection
-      value: 0
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
---- !u!1 &577435248 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7168460345335854446, guid: 5ac911041f964424db7dab37e2ea3f99, type: 3}
-  m_PrefabInstance: {fileID: 577435247}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &577435255
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 577435248}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cf33d98e79d217e41b19cee56586bb77, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _boundaryCamera: {fileID: 487259603}
-  _movementSpeed: 8
---- !u!114 &577435256
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 577435248}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Actions: {fileID: -944628639613478452, guid: 78038157bc80e3f488239371a8ab230c, type: 3}
-  m_NotificationBehavior: 0
-  m_UIInputModule: {fileID: 0}
-  m_DeviceLostEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  m_DeviceRegainedEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  m_ControlsChangedEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  m_ActionEvents: []
-  m_NeverAutoSwitchControlSchemes: 0
-  m_DefaultControlScheme: 
-  m_DefaultActionMap: Arena
-  m_SplitScreenIndex: -1
-  m_Camera: {fileID: 0}
 --- !u!1 &1269678582
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PlayerInput.inputactions
+++ b/Assets/Scripts/PlayerInput.inputactions
@@ -1,0 +1,95 @@
+{
+    "name": "PlayerInput",
+    "maps": [
+        {
+            "name": "Arena",
+            "id": "0109838d-5211-4130-a0c8-c73ebc0ed1dd",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "d3c78273-cfbb-4af4-833b-71ee60284e91",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "2D Vector",
+                    "id": "f86f8a3e-da9d-4652-9a74-48452c008c4f",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "ea2a4dd6-e5af-406e-9e9b-c814b9d9baec",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard And Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "89b4d32e-adb6-4530-9aff-d0bd8e399b92",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard And Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "c8b88904-98bf-4f72-a10d-ac3d71a7e925",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard And Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "e8c769aa-4cdf-4c30-a2d2-2ba0612f232f",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard And Mouse",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "Keyboard And Mouse",
+            "bindingGroup": "Keyboard And Mouse",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Assets/Scripts/PlayerInput.inputactions.meta
+++ b/Assets/Scripts/PlayerInput.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: 78038157bc80e3f488239371a8ab230c
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+/// <summary>
+/// Handles moving the player via PlayerInput.
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D), typeof(PlayerInput))]
+public class PlayerMovement : MonoBehaviour
+{
+    [SerializeField] private Camera _boundaryCamera;
+    [SerializeField] private float _movementSpeed = 6f;
+
+    private Rigidbody2D _rigidbody;
+    private Vector2 _movementInput = Vector2.zero;
+    private Vector2 _boundaryExtents;
+
+
+    private void Awake()
+    {
+        _rigidbody = GetComponent<Rigidbody2D>();
+
+        // Use an orthographic camera to determine boundaries, or default if null.
+        if (_boundaryCamera != null)
+            _boundaryExtents = CalculateCameraBoundary(_boundaryCamera);
+        else
+            _boundaryExtents = new Vector2(10f, 10f);
+    }
+
+    private void FixedUpdate()
+    {
+        HandleMovement();
+    }
+
+    /// <summary>
+    /// Calcuate and set the new player position when moved via input.
+    /// </summary>
+    private void HandleMovement()
+    {
+        Vector2 positionDelta = _movementInput * _movementSpeed * Time.fixedDeltaTime;
+        Vector2 newPosition = positionDelta + _rigidbody.position;
+
+        _rigidbody.MovePosition(BoundaryClamp(newPosition));
+    }
+
+    /// <summary>
+    /// Using an orthographic camera, determine the world-boundary of the screen.
+    /// </summary>
+    /// <remarks>
+    /// This does not consider the position of the camera, extents will be centered at
+    /// the world origin.
+    /// </remarks>
+    /// <param name="cam">An orthographic camera used to determine the boundary</param>
+    /// <returns>2D World-space boundaries for the player</returns>
+    private Vector2 CalculateCameraBoundary(Camera cam)
+    {
+        Vector2 extents = new Vector2();
+        extents.x = cam.orthographicSize * cam.aspect;
+        extents.y = cam.orthographicSize;
+
+        return extents;
+    }
+
+    /// <summary>
+    /// Clamps position using the boundaryExtents as a symmetric 2D bound.
+    /// </summary>
+    /// <param name="position">Position to clamp</param>
+    /// <returns>Clamped Position</returns>
+    private Vector2 BoundaryClamp(Vector2 position)
+    {
+        return new Vector2(
+            Mathf.Clamp(position.x, -_boundaryExtents.x, _boundaryExtents.x),
+            Mathf.Clamp(position.y, -_boundaryExtents.y, _boundaryExtents.y)
+        );
+    }
+
+    private void OnMove(InputValue value) => _movementInput = value.Get<Vector2>();
+}

--- a/Assets/Scripts/PlayerMovement.cs
+++ b/Assets/Scripts/PlayerMovement.cs
@@ -7,12 +7,12 @@ using UnityEngine.InputSystem;
 [RequireComponent(typeof(Rigidbody2D), typeof(PlayerInput))]
 public class PlayerMovement : MonoBehaviour
 {
-    [SerializeField] private Camera _boundaryCamera;
-    [SerializeField] private float _movementSpeed = 6f;
+    [SerializeField] private Camera _boundaryCamera;    // Camera used to calculate the playable area. Can be null.
+    [SerializeField] private float _movementSpeed = 6f; // Multiplier for movement speed
 
     private Rigidbody2D _rigidbody;
-    private Vector2 _movementInput = Vector2.zero;
-    private Vector2 _boundaryExtents;
+    private Vector2 _movementInput = Vector2.zero;      // Current movement input from player control
+    private Vector2 _boundaryExtents;                   // The half-extents of the origin-centered playable boundary.
 
 
     private void Awake()
@@ -53,6 +53,9 @@ public class PlayerMovement : MonoBehaviour
     /// <returns>2D World-space boundaries for the player</returns>
     private Vector2 CalculateCameraBoundary(Camera cam)
     {
+        // Camera's orthographic size is distance from the center to top boundary.
+        // Multiply that by the aspect ratio to get the horizontal distance.
+
         Vector2 extents = new Vector2();
         extents.x = cam.orthographicSize * cam.aspect;
         extents.y = cam.orthographicSize;
@@ -73,5 +76,6 @@ public class PlayerMovement : MonoBehaviour
         );
     }
 
+    // Input handlers
     private void OnMove(InputValue value) => _movementInput = value.Get<Vector2>();
 }

--- a/Assets/Scripts/PlayerMovement.cs.meta
+++ b/Assets/Scripts/PlayerMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cf33d98e79d217e41b19cee56586bb77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -9,6 +9,7 @@
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
+    "com.unity.toolchain.win-x86_64-linux-x86_64": "2.0.4",
     "com.unity.ugui": "1.0.0",
     "com.unity.visualscripting": "1.8.0",
     "com.unity.modules.ai": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -163,6 +163,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "2.0.5",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "2.0.4",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.5"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.31",
       "depth": 0,
@@ -192,6 +208,16 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.win-x86_64-linux-x86_64": {
+      "version": "2.0.4",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "2.0.5",
+        "com.unity.sysroot.linux-x86_64": "2.0.4"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
This PR should completely fulfill the requirements of Issue #1 .

The new InputActions asset used to set up the control mapping *PlayerInput* has also created in the `Scripts` folder.

The Player Prefab has been given a new `PlayerMovement.cs`, which captures WASD input and moves them around the screen on the scene every FixedUpdate timestep by a Serialized speed. 

Additionally, when supplied with a reference to an orthographic camera, the `PlayerMovement.cs` will automatically calculate a clamping-boundary to stop them from moving outside of the visible play area.

**Note**: The boundary camera reference is not obtained through code, and must be specified via the inspector. This will work for now, but future PRs may need to acquire a reference to the main scene camera on Awake.

![player-movement](https://user-images.githubusercontent.com/46859011/236510247-9716b846-a2d4-4687-9837-54f0739d7840.gif)
